### PR TITLE
Hide contact section and header link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 import Hero from "../components/Hero";
 import ProjectCanvas from "../components/ProjectCanvas";
-import ContactSection from "../components/ContactSection";
 import SpotifyEmbed from "../components/SpotifyEmbed";
 import { getFeaturedProjects } from "../data/projects";
 
@@ -39,10 +38,6 @@ export default function Home() {
 
       {/* Music / Vibe Check */}
       <SpotifyEmbed />
-
-      <section id="contact">
-        <ContactSection />
-      </section>
     </div>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,7 +7,6 @@ import { usePathname } from "next/navigation";
 const navLinks = [
   { href: "/#about", label: "About" },
   { href: "/#projects", label: "Projects" },
-  { href: "/#contact", label: "Contact" },
 ];
 
 export default function Header() {


### PR DESCRIPTION
### Motivation
- Remove the public contact form and its navigation entry so the contact section no longer appears on the homepage or in the header.

### Description
- Deleted the `ContactSection` import and removed the `<section id="contact">` block from `app/page.tsx`, and removed the `Contact` nav entry from `components/Header.tsx` to stop linking to the removed section.

### Testing
- Ran `npm run lint` (failed in this environment), ran `npm run build` (failed due to blocked Google Fonts fetch), and ran `npm run dev` and verified the homepage rendered without the contact section via a Playwright screenshot (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854535f0fc832e92a8e7904199cd9b)

## Summary by Sourcery

Enhancements:
- Hide the contact section content on the homepage by removing the corresponding section block.